### PR TITLE
RecSplit refactoring

### DIFF
--- a/sux/util/Vector.hpp
+++ b/sux/util/Vector.hpp
@@ -92,13 +92,13 @@ template <typename T, AllocType AT = MALLOC> class Vector : public Expandable {
 	T *data = nullptr;
 
   public:
-	Vector<T, AT>() = default;
+	Vector() = default;
 
-	explicit Vector<T, AT>(size_t length) { size(length); }
+	explicit Vector(size_t length) { size(length); }
 
-	explicit Vector<T, AT>(const T *data, size_t length) : Vector(length) { memcpy(this->data, data, length); }
+	explicit Vector(const T *data, size_t length) : Vector(length) { memcpy(this->data, data, length); }
 
-	~Vector<T, AT>() {
+	~Vector() {
 		if (data) {
 			if (AT == MALLOC) {
 				free(data);

--- a/test/function/recsplit.hpp
+++ b/test/function/recsplit.hpp
@@ -135,3 +135,33 @@ TEST(recsplit_test, small_text_dump_and_load) {
 	recsplit_unit_test(rs_load, keys);
 	remove(filename);
 }
+
+TEST(recsplit_test, small_text_dump_and_load_one_by_one) {
+	vector<string> keys;
+	keys.push_back("a");
+	keys.push_back("b");
+	keys.push_back("c");
+	keys.push_back("d");
+
+	const char *filename = "test/test_dump";
+
+	RecSplit<8> rs_dump(keys.size(), 2);
+	for (size_t i = 0; i < keys.size(); i++) rs_dump.add_key(keys[i]);
+	rs_dump.build();
+
+	fstream fs;
+	fs.exceptions(fstream::failbit | fstream::badbit);
+	fs.open(filename, fstream::out | fstream::binary | fstream::trunc);
+	fs << rs_dump;
+	fs.close();
+
+	RecSplit<8> rs_load;
+	fs.open(filename, std::fstream::in | std::fstream::binary);
+	fs >> rs_load;
+	fs.close();
+
+	for (size_t i = 0; i < rs_dump.size(); i++) ASSERT_EQ(rs_dump(keys[i]), rs_load(keys[i]));
+
+	recsplit_unit_test(rs_load, keys);
+	remove(filename);
+}


### PR DESCRIPTION
Move non-constexpr array initialization
Add RecSplit methods to add key one by one
Remove ctor/dtor template parameters made invalid in C++20
Add unit test